### PR TITLE
Fixes "Unexpected X" error in 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.2"
+        "illuminate/support": "^5.3"
     },
     "autoload": {
         "psr-4": {
@@ -21,8 +21,8 @@
         "classmap": ["tests/TestCase.php"]   
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
-        "illuminate/database": "^5.2",
-        "illuminate/cache": "^5.2"
+        "phpunit/phpunit": "^5.3",
+        "illuminate/database": "^5.3",
+        "illuminate/cache": "^5.3"
     }
 }

--- a/src/MatryoshkaServiceProvider.php
+++ b/src/MatryoshkaServiceProvider.php
@@ -20,7 +20,7 @@ class MatryoshkaServiceProvider extends ServiceProvider
         }
 
         Blade::directive('cache', function ($expression) {
-            return "<?php if (! app('Laracasts\Matryoshka\BladeDirective')->setUp{$expression}) : ?>";
+            return "<?php if (! app('Laracasts\Matryoshka\BladeDirective')->setUp({$expression})) : ?>";
         });
 
         Blade::directive('endcache', function () {


### PR DESCRIPTION
In prior versions of Laravel, when registering custom Blade directives using the directive method, the $expression passed to your directive callback contained the outer-most parenthesis. In Laravel 5.3, these outer-most parenthesis are not included in the expression passed to your directive callback.
