### PR TITLE
Extend support to laravel 5.1 & 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "^5.2"
+        "illuminate/support": "^5.1"
     },
     "autoload": {
         "psr-4": {
@@ -18,11 +18,11 @@
         }
     },
     "autoload-dev": {
-        "classmap": ["tests/TestCase.php"]   
+        "classmap": ["tests/TestCase.php"]
     },
     "require-dev": {
         "phpunit/phpunit": "^5.2",
-        "illuminate/database": "^5.2",
-        "illuminate/cache": "^5.2"
+        "illuminate/database": "^5.1",
+        "illuminate/cache": "^5.1"
     }
 }

--- a/src/MatryoshkaServiceProvider.php
+++ b/src/MatryoshkaServiceProvider.php
@@ -20,6 +20,11 @@ class MatryoshkaServiceProvider extends ServiceProvider
         }
 
         Blade::directive('cache', function ($expression) {
+            $version = explode('.', $this->app::VERSION);
+            // Starting with laravel 5.3 the parens are not included in the expression string.
+            if ($version[1] > 2) {
+                return "<?php if (! app('Laracasts\Matryoshka\BladeDirective')->setUp({$expression})) : ?>";
+            }
             return "<?php if (! app('Laracasts\Matryoshka\BladeDirective')->setUp{$expression}) : ?>";
         });
 


### PR DESCRIPTION
- Only change necessary to support 5.1 is reducing the version number in composer.json
- To support 5.3, the expression must be wrapped with parens in the blade directive
